### PR TITLE
IQ-231 not able to submit payload above 100kb

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -15,6 +15,8 @@ const BASE_URL = envVariables.BASE_URL;
 const CONTENT_PROXY_URL = envVariables.CONTENT_PROXY_URL;
 
 var app = express();
+app.use(bodyParser.json({limit: '1mb'}));
+
 app.set('port', 3000);
 app.use(express.json())
 app.use(express.static(process.cwd() + "/dist/"));


### PR DESCRIPTION
maximum request body Defaults size is '100kb'. [body parser](http://expressjs.com/en/resources/middleware/body-parser.html)
changing the max size to 1mb